### PR TITLE
show error message in the Alert modal

### DIFF
--- a/Moggles/ClientApp/src/application/AddApplication.vue
+++ b/Moggles/ClientApp/src/application/AddApplication.vue
@@ -110,8 +110,8 @@
                     setTimeout(() => {
                         this.showSuccessAlert = false;
                     }, this.alertDuration)
-                }).catch(e => {
-                    this.errors.push(e.response.data);
+                }).catch(error => {
+                    Bus.$emit(events.showErrorAlertModal, { 'error': error })
                 }).finally(() => {
                     Bus.$emit(events.unblockUI)
                 });


### PR DESCRIPTION
display error in the alert modal when adding an app with the same name as existing one